### PR TITLE
Added Timeout for Httpx

### DIFF
--- a/sef
+++ b/sef
@@ -104,9 +104,9 @@ function Output() {
 
 function Htpx() {
     echo "[=] Running HTTPx"
-    httpx -l sub.txt -silent -o sub.httpx &>/dev/null
-    httpx -l sub.txt -csp-probe -silent | grep -F ".$domain" | anew sub.httpx &>/dev/null
-    httpx -l sub.txt -tls-probe -silent | grep -F ".$domain" | anew sub.httpx &>/dev/null
+    httpx -l sub.txt -silent -timeout 20 -o sub.httpx &>/dev/null
+    httpx -l sub.txt -csp-probe -silent -timeout 20 | grep -F ".$domain" | anew sub.httpx &>/dev/null
+    httpx -l sub.txt -tls-probe -silent -timeout 20 | grep -F ".$domain" | anew sub.httpx &>/dev/null
 }
 
 


### PR DESCRIPTION
Hi Bro
I have addes -timeout 15 to httpx to  reduce the number of false positive results hope you add this to make it more efficient.  I have seen that httpx wait for 5 sec only which is not able to detect domains that takes a longer time to load hence httpx ignores it and 20 sec is the ideal time i have seen to detect most of the domains that doesn't respond quickly.